### PR TITLE
Update brand colors and add dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,8 +2,8 @@
 
 :root {
   --font-family-base: 'Inter', sans-serif;
-  --brand-primary: #3a7b99;
-  --brand-accent: #ffb703;
+  --brand-primary: #1d6fbe;
+  --brand-accent: #e67e22;
   --spacing-unit: 1rem;
 }
 
@@ -57,4 +57,14 @@ body {
   border: 1px solid var(--brand-primary);
   border-radius: 0.5rem;
   margin-bottom: calc(var(--spacing-unit) * 2);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --brand-primary: #5fa8ed;
+    --brand-accent: #ffc764;
+  }
+  .hero {
+    color: #000;
+  }
 }


### PR DESCRIPTION
## Summary
- update brand color variables for light theme
- add dark mode overrides using `prefers-color-scheme`
- tweak hero text color in dark mode for contrast

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68735522bcb0832b8f6392059ca60762